### PR TITLE
Remove Live program-specific language

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ build a game with Unity or explore the MEAN stack or try and whip up a React
 Native app. You've done a ton of learning already — it's time to apply all of
 that knowledge.
 
-First thing first — the burning question: Are we required to use Redux and Auth
-in our final project? The answer is… it depends.
-
 ## Project Requirements
 
 The listed requirements below are guidelines that should help you to determine
@@ -65,75 +62,17 @@ manager (your instructor).
 - [ ] Custom CSS
 - [ ] One significant refactor
 
-## Schedule
-
-For much of Phase 5, your time is your own. This is, however, a great
-opportunity for you to practice good time management. There are some specific
-milestones during this process - your project manager will determine the exact
-timeline for each of the following:
-
-### Week 1
-
-#### Initial Project Pitches
-
-This is when you get to pitch whatever pie in the sky things you want. We're not
-yet worried about what your MVP is or whether your idea is practical — just come
-up with ideas. You won't be starting on your project until Day 3, so think of
-this as your research and development phase. Learn Auth, learn Redux, learn how
-to use complex APIs and libraries. Your instructor will give you an idea of what
-is and isn't practical, and some guidance on the technologies you're looking at.
-
-#### Project Proposals
-
-You will have your project ready to pitch to a panel including a lead and your
-instructor. You'll have the models drawn out, a sketched out version of what
-your frontend will look like, and evidence that you're able to use the APIs and
-libraries that you're going to implement. You'll also have a proposal for what
-your MVP will look like. You're expected to have the MVP complete a week from
-this day. Together you and your instructors will determine the best project to
-move forward with.
-
-#### Retro
-
-You'll be taking part in a retro every Friday. This will be the time to talk
-about what went right, what went wrong, what roadblocks you're still up against
-and your plan of attack for getting over them.
-
-You'll also have two mandatory check-ins with your instructor leading up to your
-MVP presentation. After that, office hours will be available to sign-up for, but
-will not be mandatory.
-
-### Week 2
-
-#### MVP Presentations
-
-You will present your completed MVP to your project manager and a lead
-instructor. You should have all the functionality that you promised during your
-project proposal, as well as a plan of attack for the next week.
-
-### Week 3
-
-#### Mid-Week — Projects Complete
-
-By mid-week, you should have your project done. Time after this should be spent
-styling and fixing minor bugs only — you should be done with all the core
-functionality.
-
-#### Science Fair
-
-This is the day that you'll be showing off your projects to your peers!
-
 ## Helpful Tools
 
 ### Organization
 
-**Kanban/Scrum Board**: Because this will be the most complex project you've
+- **Kanban/Scrum Board**: Because this will be the most complex project you've
 made during this course, you'll need something to keep you organized. We
 recommend Trello or a Github Project Board. Use this to track what you're doing
 and what you need to work on. It's also a great idea to keep track of bugs that
 you're not going to immediately fix.
 
-**Pomodoro Timer**: If you don't take breaks, you'll end up hurting your eyes,
+- **Pomodoro Timer**: If you don't take breaks, you'll end up hurting your eyes,
 getting RSI (repetitive strain injury) or burning yourself out. The Pomodoro
 Timer method lets you put in solid chunks of work while also giving you regular
 breaks. We like Marinara Timer, since it's nicely customizable.


### PR DESCRIPTION
Fixes #1. The Live-specific content has been moved to a [separate repo](https://github.com/learn-co-curriculum/phase-5-live-project-schedule) and a new page has been created in Canvas.
